### PR TITLE
Added connection failure handling.

### DIFF
--- a/EFCache.Redis.Tests/EFCache.Redis.Tests.csproj
+++ b/EFCache.Redis.Tests/EFCache.Redis.Tests.csproj
@@ -51,6 +51,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\StackExchange.Redis.1.0.450\lib\net45\StackExchange.Redis.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="xunit.abstractions">

--- a/EFCache.Redis.Tests/RedisCacheTests.cs
+++ b/EFCache.Redis.Tests/RedisCacheTests.cs
@@ -101,7 +101,7 @@ namespace EFCache.Redis.Tests
 
             cache.PutItem("1", new object(), new[] { "ES1", "ES2" }, TimeSpan.MaxValue, DateTimeOffset.MaxValue);
 
-            Assert.Equal(1, cache.Count);
+            Assert.Equal(3, cache.Count); // "1", "ES1", "ES2"
 
             cache.InvalidateItem("1");
 
@@ -118,7 +118,7 @@ namespace EFCache.Redis.Tests
             cache.PutItem("1", new object(), new[] { "ES1", "ES2" }, TimeSpan.MaxValue, DateTimeOffset.Now.AddMinutes(-1));
             cache.PutItem("2", new object(), new[] { "ES1", "ES2" }, TimeSpan.MaxValue, DateTimeOffset.MaxValue);
 
-            Assert.Equal(2, cache.Count);
+            Assert.Equal(4, cache.Count); // "1", "2", "ES1", "ES2"
 
             cache.Purge();
 

--- a/EFCache.Redis.Tests/packages.config
+++ b/EFCache.Redis.Tests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="EntityFramework.Cache" version="1.0.0" targetFramework="net451" />
+  <package id="StackExchange.Redis" version="1.0.450" targetFramework="net451" />
   <package id="xunit" version="2.0.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net451" />

--- a/EFCache.Redis/EFCache.Redis.csproj
+++ b/EFCache.Redis/EFCache.Redis.csproj
@@ -46,7 +46,7 @@
     </Reference>
     <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\StackExchange.Redis.1.0.414\lib\net45\StackExchange.Redis.dll</HintPath>
+      <HintPath>..\packages\StackExchange.Redis.1.0.450\lib\net45\StackExchange.Redis.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/EFCache.Redis/IRedisCache.cs
+++ b/EFCache.Redis/IRedisCache.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using StackExchange.Redis;
 
 namespace EFCache.Redis
 {
@@ -6,5 +7,6 @@ namespace EFCache.Redis
     {
         Int64 Count { get; }
         void Purge();
+        event EventHandler<RedisConnectionException> OnConnectionError;
     }
 }

--- a/EFCache.Redis/packages.config
+++ b/EFCache.Redis/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="EntityFramework.Cache" version="1.0.0" targetFramework="net451" />
-  <package id="StackExchange.Redis" version="1.0.414" targetFramework="net451" />
+  <package id="StackExchange.Redis" version="1.0.450" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Fixes #4 (EF fails if cache is unavailable). Note that connection string must include "abortConnect=false" to be able to create disconnected multiplexer.