### PR TITLE
Handle all exceptions, not just RedisConnectionException.

### DIFF
--- a/EFCache.Redis.Tests/RedisCacheTests.cs
+++ b/EFCache.Redis.Tests/RedisCacheTests.cs
@@ -7,10 +7,6 @@ namespace EFCache.Redis.Tests
     [Serializable]
     public class TestObject
     {
-        public TestObject()
-        {
-
-        }
         public string Message { get; set; }
     }
 
@@ -174,8 +170,8 @@ namespace EFCache.Redis.Tests
         public void GetItem_does_not_crash_if_cache_is_unavailable()
         {
             var cache = new RedisCache("unknown,abortConnect=false");
-            RedisConnectionException exception = null;
-            cache.OnConnectionError += (s, e) => exception = e;
+            RedisCacheException exception = null;
+            cache.CachingFailed += (s, e) => exception = e;
 
             object item;
             var success = cache.GetItem("1", out item);
@@ -183,30 +179,34 @@ namespace EFCache.Redis.Tests
             Assert.False(success);
             Assert.Null(item);
             Assert.NotNull(exception);
+            Assert.IsType(typeof(RedisConnectionException), exception.InnerException);
+            Assert.Equal(exception.Message, "Caching failed for GetItem");
         }
-
+        
         [Fact]
         public void PutItem_does_not_crash_if_cache_is_unavailable()
         {
             var cache = new RedisCache("unknown,abortConnect=false");
-            RedisConnectionException exception = null;
-            cache.OnConnectionError += (s, e) => exception = e;
+            RedisCacheException exception = null;
+            cache.CachingFailed += (s, e) => exception = e;
 
             cache.PutItem("1", new object(), new[] { "ES1", "ES2" }, TimeSpan.MaxValue, DateTimeOffset.MaxValue);
 
             Assert.NotNull(exception);
+            Assert.IsType(typeof(RedisConnectionException), exception.InnerException);
         }
 
         [Fact]
         public void InvalidateItem_does_not_crash_if_cache_is_unavailable()
         {
             var cache = new RedisCache("unknown,abortConnect=false");
-            RedisConnectionException exception = null;
-            cache.OnConnectionError += (s, e) => exception = e;
+            RedisCacheException exception = null;
+            cache.CachingFailed += (s, e) => exception = e;
 
             cache.InvalidateItem("1");
 
             Assert.NotNull(exception);
+            Assert.IsType(typeof(RedisConnectionException), exception.InnerException);
         }
     }
 }

--- a/EFCache.Redis/EFCache.Redis.csproj
+++ b/EFCache.Redis/EFCache.Redis.csproj
@@ -66,6 +66,7 @@
       <DependentUpon>AssemblyInfo.tt</DependentUpon>
     </Compile>
     <Compile Include="RedisCache.cs" />
+    <Compile Include="RedisCacheException.cs" />
     <Compile Include="StackExchangeRedisExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/EFCache.Redis/IRedisCache.cs
+++ b/EFCache.Redis/IRedisCache.cs
@@ -7,6 +7,6 @@ namespace EFCache.Redis
     {
         Int64 Count { get; }
         void Purge();
-        event EventHandler<RedisConnectionException> OnConnectionError;
+        event EventHandler<RedisCacheException> CachingFailed;
     }
 }

--- a/EFCache.Redis/RedisCache.cs
+++ b/EFCache.Redis/RedisCache.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -11,12 +12,23 @@ namespace EFCache.Redis
     {
         private IDatabase _database;
         private readonly ConnectionMultiplexer _redis;
-        public event EventHandler<RedisConnectionException> OnConnectionError;
         private const string EntitySetKey = "__EFCache.Redis_EntitySetKey_";
+        public event EventHandler<RedisCacheException> CachingFailed;
+
         public RedisCache(string config)
         {
             _redis = ConnectionMultiplexer.Connect(config);
         }
+
+        protected virtual void OnCachingFailed(Exception e, [CallerMemberName] string memberName = "")
+        {
+            var handler = CachingFailed;
+            if (handler != null) {
+                var redisCacheException = new RedisCacheException("Caching failed for " + memberName, e);
+                handler(this, redisCacheException);
+            }
+        }
+
         public bool GetItem(string key, out object value)
         {
             _database = _redis.GetDatabase();
@@ -34,9 +46,9 @@ namespace EFCache.Redis
 
                 try {
                     value = _database.Get<CacheEntry>(key);
-                } catch (RedisConnectionException e) {
+                } catch (Exception e) {
                     value = null;
-                    RaiseConnectionError(e);
+                    OnCachingFailed(e);
                 }
 
                 if (value == null) return false;
@@ -88,8 +100,8 @@ namespace EFCache.Redis
                     foreach (var entitySet in entitySets) {
                         _database.SetAdd(GetEntitySetKey(entitySet), key);
                     }
-                } catch (RedisConnectionException e) {
-                    RaiseConnectionError(e);
+                } catch (Exception e) {
+                    OnCachingFailed(e);
                 }
 
             }
@@ -98,13 +110,6 @@ namespace EFCache.Redis
         private static RedisKey GetEntitySetKey(string entitySet)
         {
             return EntitySetKey + entitySet;
-        }
-
-        private void RaiseConnectionError(RedisConnectionException e)
-        {
-            var onConnectionError = OnConnectionError;
-            if (onConnectionError != null)
-                onConnectionError(this, e);
         }
 
         private static string HashKey(string key)
@@ -137,8 +142,8 @@ namespace EFCache.Redis
                         itemsToInvalidate.UnionWith(keys);
                         _database.KeyDelete(EntitySetKey);
                     }
-                } catch (RedisConnectionException e) {
-                    RaiseConnectionError(e);
+                } catch (Exception e) {
+                    OnCachingFailed(e);
                     return;
                 }
 
@@ -170,8 +175,8 @@ namespace EFCache.Redis
                     foreach (var set in entry.EntitySets) {
                         _database.SetRemove(GetEntitySetKey(set), key);
                     }
-                } catch (RedisConnectionException e) {
-                    RaiseConnectionError(e);
+                } catch (Exception e) {
+                    OnCachingFailed(e);
                 }
             }
         }
@@ -200,5 +205,6 @@ namespace EFCache.Redis
             }
 
         }
+
     }
 }

--- a/EFCache.Redis/RedisCacheException.cs
+++ b/EFCache.Redis/RedisCacheException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace EFCache.Redis
+{
+    public class RedisCacheException : Exception
+    {
+        public RedisCacheException()
+        {
+        }
+
+        public RedisCacheException(string message) : base(message)
+        {
+        }
+
+        public RedisCacheException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
I ran into a problem where large queries caused the Azure connection to timeout, and EF failed.

Caching should never cause Entity Framework to fail if it doesn't work.

Note, this is a slight breaking change from the last PR, as I have changed the event `IRedisCache.OnConnectionError` to `CachingFailed`, which follows .NET event naming conventions, and also passes a new `RedisCacheException` that wraps the error.