### PR TITLE
Update RedisCache.cs

### DIFF
--- a/EFCache.Redis/RedisCache.cs
+++ b/EFCache.Redis/RedisCache.cs
@@ -10,7 +10,11 @@ namespace EFCache.Redis
 {
     public class RedisCache : IRedisCache
     {
-        private IDatabase _database;
+        //Note- modifying these objects will alter locking scheme
+        private static object _globalLock;//used to put sync locks at global level; only one thread across app will access the code block locked via this
+        private object _lock;//used to put instance level lock; only one thread will execute code block per instance
+
+        private IDatabase _database;//lock don't work on this because it is being reassigned each time new connection requested; though _redis.GetDatabase() is thread safe and should be used to let mutiplexor manage connection for best performance. Considering these let's avoid putting lock on it
         private readonly ConnectionMultiplexer _redis;
         private const string EntitySetKey = "__EFCache.Redis_EntitySetKey_";
         public event EventHandler<RedisCacheException> CachingFailed;
@@ -34,19 +38,17 @@ namespace EFCache.Redis
 
         public bool GetItem(string key, out object value)
         {
-            _database = _redis.GetDatabase();
-
             if (key == null)
             {
                 throw new ArgumentNullException("key");
             }
+            _database = _redis.GetDatabase();//connect only if arguments are valid to optimize resources 
 
             key = HashKey(key);
-
-            lock (_database)
+            var now = DateTimeOffset.Now;//local variables are thread safe should be out of sync lock
+            
+            lock (_lock)
             {
-                var now = DateTimeOffset.Now;
-
                 try {
                     value = _database.Get<CacheEntry>(key);
                 } catch (Exception e) {
@@ -72,8 +74,8 @@ namespace EFCache.Redis
             }
 
             return false;
-
         }
+        
         private static bool EntryExpired(CacheEntry entry, DateTimeOffset now)
         {
             return entry.AbsoluteExpiration < now || (now - entry.LastAccess) > entry.SlidingExpiration;
@@ -81,23 +83,22 @@ namespace EFCache.Redis
 
         public void PutItem(string key, object value, IEnumerable<string> dependentEntitySets, TimeSpan slidingExpiration, DateTimeOffset absoluteExpiration)
         {
-            _database = _redis.GetDatabase();
             if (key == null)
             {
                 throw new ArgumentNullException("key");
             }
 
-            key = HashKey(key);
-
             if (dependentEntitySets == null)
             {
                 throw new ArgumentNullException("dependentEntitySets");
             }
+            _database = _redis.GetDatabase();
+            
+            key = HashKey(key);
+            var entitySets = dependentEntitySets.ToArray();
 
-            lock (_database)
+            lock (_lock)
             {
-                var entitySets = dependentEntitySets.ToArray();
-
                 try {
                     _database.Set(key, new CacheEntry(value, entitySets, slidingExpiration, absoluteExpiration));
                     foreach (var entitySet in entitySets) {
@@ -128,16 +129,16 @@ namespace EFCache.Redis
 
         public void InvalidateSets(IEnumerable<string> entitySets)
         {
-            _database = _redis.GetDatabase();
             if (entitySets == null)
             {
                 throw new ArgumentNullException("entitySets");
             }
+            _database = _redis.GetDatabase();
+            
+            var itemsToInvalidate = new HashSet<string>();
 
-            lock (_database)
+            lock (_lock)
             {
-                var itemsToInvalidate = new HashSet<string>();
-
                 try {
                     foreach (var entitySet in entitySets) {
                         var entitySetKey = GetEntitySetKey(entitySet);
@@ -159,15 +160,15 @@ namespace EFCache.Redis
 
         public void InvalidateItem(string key)
         {
-            _database = _redis.GetDatabase();
             if (key == null)
             {
                 throw new ArgumentNullException("key");
             }
+            _database = _redis.GetDatabase();
 
             key = HashKey(key);
 
-            lock (_database) {
+            lock (_lock) {
                 try {
                     var entry = _database.Get<CacheEntry>(key);
 
@@ -188,7 +189,7 @@ namespace EFCache.Redis
             get
             {
                 _database = _redis.GetDatabase();
-                lock (_database)
+                lock (_lock)
                 {
                     var count = _database.Multiplexer.GetEndPoints()
                         .Sum(endpoint => _database.Multiplexer.GetServer(endpoint).Keys(pattern: "*").LongCount());
@@ -199,7 +200,7 @@ namespace EFCache.Redis
         public void Purge()
         {
             _database = _redis.GetDatabase();
-            lock (_database)
+            lock (_globalLock)
             {
                 foreach (var endPoint in _database.Multiplexer.GetEndPoints())
                 {


### PR DESCRIPTION
Changes -
1- Removed locks on "_database", it was not thread safe, this object was reset with _redis.GetDatabase(). Though _redis.GetDatabase() is best for performance because it lets multiplexer take care of connection part.
2- Separate lock objects for local and global locks.
3- Other code optimizations.
Note- These changes are based on 20VU load test for best performance.