### PR TITLE
Fixed issue #21

### DIFF
--- a/EFCache.Redis/RedisCache.cs
+++ b/EFCache.Redis/RedisCache.cs
@@ -83,6 +83,19 @@ namespace EFCache.Redis
             {
                 entry.LastAccess = now;
                 value = entry.Value;
+                // Update the entry in Redis to save the new LastAccess value.
+                lock (_lock)
+                {
+                    try
+                    {
+                        _database.Set(key, entry);
+                    }
+                    catch (Exception e)
+                    {
+                        // Eventhough an error has occured, we will return true, because the retrieval of the entity was a success
+                        OnCachingFailed(e);
+                    }
+                }
                 return true;
             }
 


### PR DESCRIPTION
As I explained in Issue #21, there is a problem with the SlidingExpiration. 
With this update the changed LastAccess property is written back to Redis and as such all subsequent retrievals will have the correct data to asses if the item exceeded its SlidingExpiration timeout.