### PR TITLE
Add the connection multiplexer to be provided explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.vs
 
 # Build results
 

--- a/EFCache.Redis.Tests/EFCache.Redis.Tests.csproj
+++ b/EFCache.Redis.Tests/EFCache.Redis.Tests.csproj
@@ -51,12 +51,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\StackExchange.Redis.1.1.603\lib\net45\StackExchange.Redis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.2.6\lib\net45\StackExchange.Redis.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="xunit.abstractions">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>

--- a/EFCache.Redis.Tests/packages.config
+++ b/EFCache.Redis.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="EntityFramework.Cache" version="1.0.0" targetFramework="net451" />
-  <package id="StackExchange.Redis" version="1.1.603" targetFramework="net451" requireReinstallation="true" />
+  <package id="StackExchange.Redis" version="1.2.6" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />

--- a/EFCache.Redis/EFCache.Redis.csproj
+++ b/EFCache.Redis/EFCache.Redis.csproj
@@ -45,13 +45,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\StackExchange.Redis.1.1.603\lib\net45\StackExchange.Redis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.2.6\lib\net45\StackExchange.Redis.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/EFCache.Redis/RedisCache.cs
+++ b/EFCache.Redis/RedisCache.cs
@@ -11,6 +11,8 @@ namespace EFCache.Redis
     // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
     public class RedisCache : IRedisCache
     {
+        private const string DefaultCacheIdentifier = "__EFCache.Redis_EntitySetKey_";
+
         //Note- modifying these objects will alter locking scheme
         private readonly object _lock = new object();//used to put instance level lock; only one thread will execute code block per instance
 
@@ -25,9 +27,15 @@ namespace EFCache.Redis
         public RedisCache(ConfigurationOptions options)
         {
             _redis = ConnectionMultiplexer.Connect(options);
-            _cacheIdentifier = "__EFCache.Redis_EntitySetKey_"; 
+            _cacheIdentifier = DefaultCacheIdentifier; 
         }
-        
+
+        public RedisCache(ConnectionMultiplexer connection, string cacheIdentifier = DefaultCacheIdentifier)
+        {
+            _redis = connection;
+            _cacheIdentifier = cacheIdentifier;
+        }
+
         public RedisCache(string config, string cacheIdentifier)
         {
             _redis = ConnectionMultiplexer.Connect(ConfigurationOptions.Parse(config));

--- a/EFCache.Redis/packages.config
+++ b/EFCache.Redis/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="EntityFramework.Cache" version="1.0.0" targetFramework="net451" />
-  <package id="StackExchange.Redis" version="1.1.603" targetFramework="net451" requireReinstallation="true" />
+  <package id="StackExchange.Redis" version="1.2.6" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
In some cases it is highly desirable to provide a pre-existing singleton connection multiplexer instead of allowing EFCache.Redis to create it's own one.

This PR also updates the version of Stackexchange.Redis to fix connectivity with redis when running in cluster mode, which is currently broken (see https://github.com/StackExchange/StackExchange.Redis/issues/670)